### PR TITLE
Feat: LayoutGridField

### DIFF
--- a/src/components/fields/LayoutGridField.tsx
+++ b/src/components/fields/LayoutGridField.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { Grid, Box } from '@mui/material';
+import type { FieldProps } from '@rjsf/utils';
+import { getUiOptions } from '@rjsf/utils';
+
+const parseGridClassName = (className: string = ''): number => {
+  const colMatch = className.match(/col-xs-(\d+)/);
+  return colMatch ? parseInt(colMatch[1], 10) : 12;
+};
+
+const getNestedProperty = (obj: any, path: string): any => {
+  if (!obj || !path) return undefined;
+  return path.split('.').reduce((current, key) => current?.[key], obj);
+};
+
+const renderChildren = (children: any[], registry: any, formData: any, onChange: any, errorSchema: any, schema: any, uiSchema: any): React.ReactElement[] => {
+  if (!children) return [];
+  
+  return children.map((child, index) => {
+    if (typeof child === 'string') {
+      const fieldPath = child;
+      const fieldSchema = getNestedProperty(schema.properties, fieldPath);
+      const fieldUiSchema = getNestedProperty(uiSchema, fieldPath) || {};
+      const fieldData = getNestedProperty(formData, fieldPath);
+      
+      if (fieldSchema) {
+        const SchemaField = registry.fields.SchemaField;
+        return (
+          <SchemaField
+            key={`${fieldPath}-${index}`}
+            name={fieldPath}
+            schema={fieldSchema}
+            uiSchema={fieldUiSchema}
+            formData={fieldData}
+            onChange={(newFieldData: any) => {
+              const newFormData = { ...formData, [fieldPath]: newFieldData };
+              onChange(newFormData);
+            }}
+            onBlur={() => {}}
+            onFocus={() => {}}
+            registry={registry}
+            disabled={false}
+            readonly={false}
+            autofocus={false}
+            errorSchema={getNestedProperty(errorSchema, fieldPath) || {}}
+            idSchema={{ $id: fieldPath }}
+            rawErrors={[]}
+          />
+        );
+      }
+    }
+    
+    return <div key={index}></div>;
+  });
+};
+
+const renderRow = (rowConfig: any, registry: any, formData: any, onChange: any, errorSchema: any, schema: any, uiSchema: any, key: number): React.ReactElement => {
+  const { className = '', children = [] } = rowConfig;
+  
+  return (
+    <Grid container spacing={2} className={className} key={`row-${key}`} sx={{ mb: 2 }}>
+      {children.map((child: any, index: number) => {
+        if (child['ui:col'] || child['ui:columns']) {
+          const colConfig = child['ui:col'] || child['ui:columns'];
+          return renderColumn(colConfig, registry, formData, onChange, errorSchema, schema, uiSchema, index);
+        }
+        return null;
+      })}
+    </Grid>
+  );
+};
+
+const renderColumn = (colConfig: any, registry: any, formData: any, onChange: any, errorSchema: any, schema: any, uiSchema: any, key: number): React.ReactElement => {
+  const { className = '', children = [], style = {} } = colConfig;
+  const gridSize = parseGridClassName(className);
+  
+  return (
+    <Grid size={gridSize} className={className} key={`col-${key}`}>
+      <Box sx={{ 
+        ...style, 
+        '& > *': { 
+          mb: 2 
+        },
+        '& > *:last-child': {
+          mb: 0
+        }
+      }}>
+        {renderChildren(children, registry, formData, onChange, errorSchema, schema, uiSchema)}
+      </Box>
+    </Grid>
+  );
+};
+
+const LayoutGridField: React.FC<FieldProps> = (props) => {
+  const { uiSchema, formData, onChange, errorSchema, schema, registry } = props;
+  const options = getUiOptions(uiSchema);
+  const layoutGrid = options.layoutGrid;
+  
+  if (!layoutGrid || !layoutGrid['ui:row']) {
+    return <div>No layout configuration found</div>;
+  }
+  
+  const rows = Array.isArray(layoutGrid['ui:row']) ? layoutGrid['ui:row'] : [layoutGrid['ui:row']];
+  
+  return (
+    <Box sx={{ '& > *:last-child': { mb: '0 !important' } }}>
+      {rows.map((row, index) => {
+        if (row['ui:row']) {
+          return renderRow(row['ui:row'], registry, formData, onChange, errorSchema, schema, uiSchema, index);
+        }
+        return null;
+      })}
+    </Box>
+  );
+};
+
+export default LayoutGridField;

--- a/src/components/fields/LayoutHeaderField.tsx
+++ b/src/components/fields/LayoutHeaderField.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Typography, Box, Divider } from '@mui/material';
+import type { FieldProps } from '@rjsf/utils';
+
+const LayoutHeaderField: React.FC<FieldProps> = (props) => {
+  const { schema, children } = props;
+  const title = schema.title || '';
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      {title && (
+        <>
+          <Typography variant="h6" component="h3" sx={{ mb: 2, fontWeight: 600 }}>
+            {title}
+          </Typography>
+          <Divider sx={{ mb: 2 }} />
+        </>
+      )}
+      {children}
+    </Box>
+  );
+};
+
+export default LayoutHeaderField;

--- a/src/components/fields/index.ts
+++ b/src/components/fields/index.ts
@@ -1,0 +1,9 @@
+import LayoutGridField from './LayoutGridField';
+import LayoutHeaderField from './LayoutHeaderField';
+
+export const customFields = {
+  LayoutGridField,
+  LayoutHeaderField,
+};
+
+export { LayoutGridField, LayoutHeaderField };

--- a/src/components/molecules/FieldSettingsForm.tsx
+++ b/src/components/molecules/FieldSettingsForm.tsx
@@ -78,6 +78,20 @@ export default function FieldSettingsForm({ field, onUpdate }: FieldSettingsForm
         label="Required"
       />
 
+      <TextField
+        label="Width (%)"
+        type="number"
+        value={field?.width ?? 100}
+        onChange={(e) => {
+          const width = Number(e.target.value);
+          onUpdate({ width: width === 100 ? undefined : width });
+        }}
+        size="small"
+        inputProps={{ min: 1, max: 100 }}
+        helperText="Field width percentage (1-100). Use less than 100% to enable grid layout."
+        fullWidth
+      />
+
       {/* Widget selector */}
       {(field?.type === "boolean" || field?.type === "select") && (
         <Stack direction="row" spacing={2} alignItems="center">

--- a/src/components/organisms/FormPreview.tsx
+++ b/src/components/organisms/FormPreview.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, Stack, Typography, Chip, Box, Paper, Button, alpha } from "@mui/material";
 import Form from "@rjsf/mui";
 import validator from "@rjsf/validator-ajv8";
+import { customFields } from "../fields";
 
 interface FormPreviewProps {
   fieldsCount: number;
@@ -108,6 +109,7 @@ export default function FormPreview({ fieldsCount, schema, uiSchema, onClearAll 
                 schema={schema}
                 uiSchema={uiSchema}
                 validator={validator}
+                fields={customFields}
                 onSubmit={({ formData }) => {
                   alert(JSON.stringify(formData, null, 2));
                 }}

--- a/src/types/field.ts
+++ b/src/types/field.ts
@@ -19,4 +19,8 @@ export interface Field {
   rows?: number;
   inline?: boolean;
   disabled?: boolean;
+  
+  // Layout properties
+  width?: number;
+  layoutField?: string;
 }


### PR DESCRIPTION
This pull request introduces a flexible grid layout system for form fields, allowing users to specify field widths and automatically generating a responsive grid structure in the form preview. It adds two custom field components (`LayoutGridField` and `LayoutHeaderField`), updates the field settings to support width configuration, and modifies the form generation logic to use the new grid layout when any field has a custom width. These changes enhance the form builder's layout capabilities and user experience.

**Grid Layout System and Field Widths**
- Added a `width` property to the `Field` type, allowing each field to specify its width as a percentage.
- Updated the field settings form (`FieldSettingsForm.tsx`) to include a "Width (%)" input, letting users set the width for each field.

**Custom Field Components**
- Implemented `LayoutGridField` and `LayoutHeaderField` React components to render fields in a grid and section headers, respectively, using Material UI's grid system. [[1]](diffhunk://#diff-315c9317ea5d05892f17b6e812c93cd47dbd3b2c5a38d0c2d2cb3df63aa83207R1-R117) [[2]](diffhunk://#diff-6cf8bb6a1686a173c3aea63d5471dc5b2307205b48faddf40760050f6fe5ace5R1-R24)
- Registered these custom fields in `fields/index.ts` for use in forms.

**Form Generation and Preview Logic**
- Enhanced the form schema and `uiSchema` generation logic in `HomePage.tsx` to detect fields with custom widths and build a nested grid layout structure accordingly, mapping field widths to 12-column grid spans. [[1]](diffhunk://#diff-e2b6d675baa9863eb1e96b0328af8cb9df3410bdd74fd393f682db5a922e91f8R74-R75) [[2]](diffhunk://#diff-e2b6d675baa9863eb1e96b0328af8cb9df3410bdd74fd393f682db5a922e91f8R143-R212)
- Integrated the custom fields into the form preview component so that forms render using the new grid layout when applicable. [[1]](diffhunk://#diff-d12d9c20cd5b09c61f562a5a7b3c51ff25221b3d35869846f282b4dfb52a1926R4) [[2]](diffhunk://#diff-d12d9c20cd5b09c61f562a5a7b3c51ff25221b3d35869846f282b4dfb52a1926R112)