### PR TITLE
feat: reset formData on schema change and add key to Form component

### DIFF
--- a/src/components/organisms/FormPreview.tsx
+++ b/src/components/organisms/FormPreview.tsx
@@ -60,6 +60,10 @@ export default function FormPreview({ fieldsCount, schema, uiSchema, onClearAll 
     }
   }, [fieldsCount]);
 
+  useEffect(() => {
+    setFormData({});
+  }, [schema]);
+
   const handleTestForm = () => {
     const form = document.querySelector("form");
     if (form) {
@@ -114,6 +118,7 @@ export default function FormPreview({ fieldsCount, schema, uiSchema, onClearAll 
           <Box sx={{ flex: 1, overflow: "auto", px: 3, pb: 2 }}>
             <Paper sx={FormStyles}>
               <Form
+                key={JSON.stringify(Object.keys(schema.properties || {}))}
                 schema={schema}
                 uiSchema={uiSchema}
                 formData={formData}


### PR DESCRIPTION
This pull request improves the behavior of the `FormPreview` component to ensure the form resets correctly when the schema changes. The main changes help prevent stale form data and ensure the form re-renders appropriately.

Form state and rendering improvements:

* Added a `useEffect` hook to reset `formData` to an empty object whenever the `schema` changes, ensuring the form does not display outdated data when the schema is updated.
* Set a dynamic `key` prop on the `Form` component based on the schema's property keys, forcing React to fully remount the form when the schema structure changes. This helps clear any internal state and ensures the form reflects the new schema.